### PR TITLE
Parameter history

### DIFF
--- a/Python/main.py
+++ b/Python/main.py
@@ -176,6 +176,13 @@ class PrettyWidget(QtWidgets.QMainWindow):
         btn_fit.resize(btn_fit.sizeHint())
         btn_fit.clicked.connect(self.fit)
         grid.addWidget(btn_fit, 1, 2, 1, 1)
+        
+        # Undo Fit Button
+        btn_undoFit = QtWidgets.QPushButton('undo Fit', self)
+        btn_undoFit.resize(btn_undoFit.sizeHint())
+        btn_undoFit.clicked.connect(self.one_step_back_in_params_history)
+        grid.addWidget(btn_undoFit, 4, 2, 1, 1)
+
 
         # Add Button
         btn_add = QtWidgets.QPushButton('add peak', self)
@@ -1177,6 +1184,10 @@ class PrettyWidget(QtWidgets.QMainWindow):
                 return self.raise_error("Error: Fitting was not successful.")
     def interrupt_fit(self):
         print("does nothing yet")
+
+    def one_step_back_in_params_history(self):
+        self.go_back_in_paramaeter_history = False
+        self.fit()
 
     def history_manager(self,pars):
         if self.go_back_in_paramaeter_history:

--- a/Python/main.py
+++ b/Python/main.py
@@ -2308,7 +2308,7 @@ class PrettyWidget(QtWidgets.QMainWindow):
             # ax.plot(x, init+bg_mod, 'b--', lw =2, label='initial')
             if plottitle != '':
                 self.ar.set_title(r"{}".format(plottitle), fontsize=11)
-            self.ax.plot(x, out.best_fit + bg_mod, 'k-', lw=2, label='initial')
+            #self.ax.plot(x, out.best_fit + bg_mod, 'k-', lw=2, label='initial')
 
             for index_pk in range(npeak):
                 # print(index_pk, color)

--- a/Python/main.py
+++ b/Python/main.py
@@ -87,6 +87,8 @@ class PrettyWidget(QtWidgets.QMainWindow):
         self.floating = None
         self.version = None
         self.df = None
+        self.parameter_history = []
+        self.go_back_in_paramaeter_history = False
         self.event_stop = threading.Event()
         self.initUI()
         self.error_dialog = QtWidgets.QErrorMessage()
@@ -1911,6 +1913,15 @@ class PrettyWidget(QtWidgets.QMainWindow):
         if mode == 'eva':
             out = mod.fit(y, pars, x=x, y=y)
         else:
+             if self.go_back_in_paramaeter_history:
+                try:
+                    pars = self.parameter_history.pop()
+                    self.go_back_in_paramaeter_history = False
+                except IndexError:
+                    return self.raise_error('No further steps are saved')
+                    self.go_back_in_paramaeter_history = False
+            else:
+                self.parameter_history.append(pars)
             out = mod.fit(y, pars, x=x, weights=1 / np.sqrt(raw_y), y=raw_y)
         comps = out.eval_components(x=x)
         # fit results to be checked

--- a/Python/main.py
+++ b/Python/main.py
@@ -1177,6 +1177,19 @@ class PrettyWidget(QtWidgets.QMainWindow):
                 return self.raise_error("Error: Fitting was not successful.")
     def interrupt_fit(self):
         print("does nothing yet")
+
+    def history_manager(self,pars):
+        if self.go_back_in_paramaeter_history:
+                try:
+                    pars = self.parameter_history.pop()
+                    self.go_back_in_paramaeter_history = False
+                except IndexError:
+                    return self.raise_error('No further steps are saved')
+                    self.go_back_in_paramaeter_history = False
+        else:
+            self.parameter_history.append(pars)
+        return pars
+
     def ana(self, mode):
         plottitle = self.plottitle.displayText()
         # self.df = np.loadtxt(str(self.comboBox_file.currentText()), delimiter=',', skiprows=1)
@@ -1913,15 +1926,8 @@ class PrettyWidget(QtWidgets.QMainWindow):
         if mode == 'eva':
             out = mod.fit(y, pars, x=x, y=y)
         else:
-             if self.go_back_in_paramaeter_history:
-                try:
-                    pars = self.parameter_history.pop()
-                    self.go_back_in_paramaeter_history = False
-                except IndexError:
-                    return self.raise_error('No further steps are saved')
-                    self.go_back_in_paramaeter_history = False
-            else:
-                self.parameter_history.append(pars)
+            pars = self.history_manager(pars) 
+            #print(self.parameter_history)
             out = mod.fit(y, pars, x=x, weights=1 / np.sqrt(raw_y), y=raw_y)
         comps = out.eval_components(x=x)
         # fit results to be checked


### PR DESCRIPTION
My previous comment #13  about creating a parameter class for the "undo fit" functionality is not as practical as I thought at the beginning. The parameters are already inizialized in the lmfit.Parameters.parameter classe and you also need the presets for the GUI. 

So here I added a history_manager() and one_step_back_in_params_history() methods which create a list self.parameter_history_list and handle the history of the fits. 

Notice:
    At the moment after pressing "undo Fit" button the parameters/presets are set to the previous value and it is fit again, because the evaluation method doesn't work for me, better said I didn't test it enough. 