### PR TITLE
Add new log location to when using Flatpak.

### DIFF
--- a/Python/main.py
+++ b/Python/main.py
@@ -29,7 +29,11 @@ import logging  # error handling
 from logging.handlers import RotatingFileHandler
 import configparser
 
-print(os.environ)
+flatpak_env = os.environ.get('flatpak')
+if flatpak_env is not None and flatpak_env != '':
+    print(True)
+else:
+    print(False)
 
 script_directory = os.path.dirname(os.path.abspath(__file__))
 log_folder = os.path.join(script_directory, '../Logs')

--- a/Python/main.py
+++ b/Python/main.py
@@ -29,8 +29,8 @@ import logging  # error handling
 from logging.handlers import RotatingFileHandler
 import configparser
 
-flatpak_env = os.environ.get('flatpak')
-if flatpak_env is not None and flatpak_env != '':
+flatpak_env = os.environ.get('container')
+if flatpak_env is 'flatpak':
     print(True)
 else:
     print(False)

--- a/Python/main.py
+++ b/Python/main.py
@@ -29,6 +29,8 @@ import logging  # error handling
 from logging.handlers import RotatingFileHandler
 import configparser
 
+print(os.environ)
+
 script_directory = os.path.dirname(os.path.abspath(__file__))
 log_folder = os.path.join(script_directory, '../Logs')
 os.makedirs(log_folder, exist_ok=True)

--- a/Python/main.py
+++ b/Python/main.py
@@ -30,13 +30,11 @@ from logging.handlers import RotatingFileHandler
 import configparser
 
 if os.environ.get('container') == 'flatpak':
-    print(True)
     user_home_folder = os.path.expanduser('~')
-    log_folder = os.path.join(user_home_folder,'.LG4X_V2/Logs')   
+    log_folder = os.path.join(user_home_folder,'.LG4X_V2/Logs')
     os.makedirs(log_folder, exist_ok=True)
     log_file_path = os.path.join(user_home_folder, '.LG4X_V2/Logs/app.log')
 else:
-    print(False)
     script_directory = os.path.dirname(os.path.abspath(__file__))
     log_folder = os.path.join(script_directory, '../Logs')
     os.makedirs(log_folder, exist_ok=True)

--- a/Python/main.py
+++ b/Python/main.py
@@ -29,16 +29,19 @@ import logging  # error handling
 from logging.handlers import RotatingFileHandler
 import configparser
 
-flatpak_env = os.environ.get('container')
-if flatpak_env is 'flatpak':
+if os.environ.get('container') == 'flatpak':
     print(True)
+    user_home_folder = os.path.expanduser('~')
+    log_folder = os.path.join(user_home_folder,'.LG4X_V2/Logs')   
+    os.makedirs(log_folder, exist_ok=True)
+    log_file_path = os.path.join(user_home_folder, '.LG4X_V2/Logs/app.log')
 else:
     print(False)
-
-script_directory = os.path.dirname(os.path.abspath(__file__))
-log_folder = os.path.join(script_directory, '../Logs')
-os.makedirs(log_folder, exist_ok=True)
-log_file_path = os.path.join(script_directory, '../Logs/app.log')
+    script_directory = os.path.dirname(os.path.abspath(__file__))
+    log_folder = os.path.join(script_directory, '../Logs')
+    os.makedirs(log_folder, exist_ok=True)
+    log_file_path = os.path.join(script_directory, '../Logs/app.log')
+    
 max_log_size = 4*1024*1024 # 4MB
 backup_count = 5  # Number of backup files to keep
 handler = RotatingFileHandler(log_file_path, maxBytes=max_log_size, backupCount=backup_count)

--- a/Python/main.py
+++ b/Python/main.py
@@ -31,9 +31,9 @@ import configparser
 
 if os.environ.get('container') == 'flatpak':
     user_home_folder = os.path.expanduser('~')
-    log_folder = os.path.join(user_home_folder,'.LG4X_V2/Logs')
+    log_folder = os.path.join(user_home_folder,'.var/app/io.github.julian_hochhaus.LG4X_V2/cache/Logs')
     os.makedirs(log_folder, exist_ok=True)
-    log_file_path = os.path.join(user_home_folder, '.LG4X_V2/Logs/app.log')
+    log_file_path = os.path.join(user_home_folder, '.var/app/io.github.julian_hochhaus.LG4X_V2/cache/Logs/app.log')
 else:
     script_directory = os.path.dirname(os.path.abspath(__file__))
     log_folder = os.path.join(script_directory, '../Logs')

--- a/data/io.github.julian_hochhaus.LG4X_V2.metainfo.xml
+++ b/data/io.github.julian_hochhaus.LG4X_V2.metainfo.xml
@@ -32,8 +32,8 @@
  <url type="bugtracker">https://github.com/Julian-Hochhaus/LG4X-V2/issues</url>
  <content_rating type="oars-1.1"/>
  <releases>
+     <release version="2.1.5" date="2023-08-19"/>
      <release version="V2.1.0" date="2023-07-19"/>
      <release version="V2.0.4" date="2023-05-15"/>
-     <release version="2.1.5" date="2023-08-19"/>
  </releases>
 </component>


### PR DESCRIPTION
Hi,
This add exception to Flatpak. In LG4X Flatpak, the main.py is install in /app/bin which does not allow creation of new file on that directory. So I add exception to Flatpak to create log folder in user home directory instead.
LG4X is aware if it in Flatpak container by looking for the container environment variable.

In addition, I move the release tag in metainfo to the top.
I hope this is fine.

Edit: Since this is unique to Flatpak, I decide it would be more appropriate to put it in `.var/app/io.github.julian_hochhaus.LG4X_V2/cache` rather than home since I do not need to writing to home dir in Flatpak.