### PR TITLE
Warn rather than fail if vamas file ends before experiment terminator

### DIFF
--- a/Python/vamas.py
+++ b/Python/vamas.py
@@ -70,8 +70,13 @@ class VAMAS:
 			self.blocks.append(VAMASBlock(self.header, content)) # Block is an object
 		
 		# Should now get the experiment terminator: check.
+
+		try:
+			check_line = next(content).strip()
+		except StopIteration:
+			# Reached end of file
+			check_line = None
 		
-		check_line = next(content).strip()
 		if check_line != 'end of experiment':
 			print('Warning (VAMAS.py, VAMAS::LoadFromText): Failed to find experiment terminator in expected place. VAMAS file may be corrupt.')
 		


### PR DESCRIPTION
Vamas files with no line after the ordinate values would fail to open. Instead print the same warning as is given when there is an unexpected line.